### PR TITLE
Minor correction to the site_summary function documentation

### DIFF
--- a/R/site_summary.R
+++ b/R/site_summary.R
@@ -4,7 +4,7 @@
 # #' @param tag variable of x with the tag ID
 # #' @param time variable of x with the detection time. For ORFID data it can be the either arrival (default = ARR) or departure (default = DEP).
 # #' @param type variable of x with the tag type (ORFID default = TTY)
-#' @details A data frame is created in the user environment with the data grouped by TAG IDs.
+#' @details A data frame is created in the user environment with the data grouped by location.
 #' @return Returns a tibble object.
 #' @author Hugo Marques <biohmarques@@gmail.com>
 #' @seealso 


### PR DESCRIPTION
I haven't ever contributed to another users repo, so I wanted to give it a try! I think you had a typo in your site_summary documentation, where you said the final table was grouped by tag id, but it's actually grouped by location.